### PR TITLE
show logs for Recipe.load

### DIFF
--- a/mrblib/mitamae/recipe.rb
+++ b/mrblib/mitamae/recipe.rb
@@ -4,6 +4,7 @@ module MItamae
     # @param parent [MItamae::RecipeRoot]
     # @param variables [Hash]
     def self.load(path, parent, variables)
+      MItamae.logger.debug "Loading recipe: #{path}"
       path = File.expand_path(path)
       Recipe.new(path, parent).tap do |recipe|
         source = File.read(path)


### PR DESCRIPTION
Show recipe files **on loading**.

By default, mitamae shows recipe files to execute as INFO level, but once the loading fails (e.g. syntax errors, no such file or directory, is a directory, etc.) debugging is not easy:

```
mruby/bin/mitamae local --log-level=debug .
 INFO : Starting MItamae...
trace:
       (snip)
	[14] (path to)/mitamae/mrblib/mitamae.rb:2:in Object.__main__
(path to)/mitamae/mruby/build/mrbgems/mruby-io/mrblib/io.rb:175: Is a directory - sysread failed (Errno::EISDIR)
```

It includes no information about filenames.

With this PR, the logs include the file name like:

```
DEBUG : Loading recipe: . # <- filename
```