### PR TITLE
Strip "default: " prefix from gem versions

### DIFF
--- a/mrblib/mitamae/resource_executor/gem_package.rb
+++ b/mrblib/mitamae/resource_executor/gem_package.rb
@@ -47,7 +47,7 @@ module MItamae
         run_command([*Array(attributes.gem_binary), 'list', '-l']).stdout.each_line do |line|
           if /\A([^ ]+) \(([^\)]+)\)\z/ =~ line.strip
             name = $1
-            versions = $2.split(', ')
+            versions = $2.split(', ').map { |v| v.sub(/\Adefault: /, '') }
             gems << {name: name, versions: versions}
           end
         end

--- a/spec/integration/gem_package_spec.rb
+++ b/spec/integration/gem_package_spec.rb
@@ -17,7 +17,11 @@ describe 'gem_package resource' do
     its(:stdout) { should_not include('itamae-template') }
   end
 
-  describe command('ri Bundler') do
-    its(:stderr) { should eq("Nothing known about Bundler\n") }
+  describe command('ri Rake') do
+    its(:stderr) { should eq("Nothing known about Rake\n") }
+  end
+
+  describe file('/tmp/bundler_is_installed') do
+    it { should_not be_file }
   end
 end

--- a/spec/recipes/gem_package.rb
+++ b/spec/recipes/gem_package.rb
@@ -1,3 +1,13 @@
+# `gem update --system` says:
+#
+# ERROR:  While executing gem ... (RuntimeError)
+#     gem update --system is disabled on Debian, because it will overwrite the content of the rubygems Debian package, and might break your Debian system in subtle ways. The Debian-supported way to update rubygems is through apt-get, using Debian official repositories.
+# If you really know what you are doing, you can still update rubygems by setting the REALLY_GEM_UPDATE_SYSTEM environment variable, but please remember that this is completely unsupported by Debian.
+
+execute 'env REALLY_GEM_UPDATE_SYSTEM=1 gem update --no-ri --no-rdoc --system 2.7.3' do
+  not_if { run_command('gem --version').stdout.chomp == '2.7.3' }
+end
+
 gem_package 'tzinfo' do
   version '1.1.0'
 end
@@ -6,8 +16,19 @@ gem_package 'tzinfo' do
   version '1.2.2'
 end
 
+gem_package 'rake' do
+  version '12.0.0' # rake >= 12.3.0 doesn't support Ruby 1.9.3 which is used in k0kubun/mitamae-spec container
+  options ['--no-document']
+end
+
+# default gem
 gem_package 'bundler' do
-  options ['--no-ri', '--no-rdoc']
+  version '1.16.0'
+  notifies :create, 'file[/tmp/bundler_is_installed]'
+end
+
+file '/tmp/bundler_is_installed' do
+  action :nothing
 end
 
 gem_package 'unindent' do


### PR DESCRIPTION
`gem list -l` shows "default: " prefix for default gems since v2.6.3.
https://github.com/rubygems/rubygems/pull/1570

Before

```
% cat test.rb
gem_package 'bigdecimal' do
  version '1.3.0'
end
% gem --version
2.6.13
% mruby/build/host/bin/mitamae local test.rb --dry-run
 INFO : Starting MItamae...
 INFO : Recipe: /home/eagletmt/.ghq/github.com/k0kubun/mitamae/test.rb
 INFO :   gem_package[bigdecimal] version will change from 'default: 1.3.0' to '1.3.0'
```

After

```
% mruby/build/host/bin/mitamae local test.rb --dry-run
 INFO : Starting MItamae...
 INFO : Recipe: /home/eagletmt/.ghq/github.com/k0kubun/mitamae/test.rb
```