### PR TITLE
Install mruby-at_exit

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -17,6 +17,7 @@ MRuby::Gem::Specification.new('mitamae') do |spec|
   spec.add_dependency 'mruby-struct',      core: 'mruby-struct'
   spec.add_dependency 'mruby-symbol-ext',  core: 'mruby-symbol-ext'
 
+  spec.add_dependency 'mruby-at_exit',     mgem: 'mruby-at_ext'
   spec.add_dependency 'mruby-dir',         mgem: 'mruby-dir'
   spec.add_dependency 'mruby-dir-glob',    mgem: 'mruby-dir-glob'
   spec.add_dependency 'mruby-env',         mgem: 'mruby-env'


### PR DESCRIPTION
I wanted to use at_exit in local_ruby_block. This is for recipe's convenience, not for mitamae's internal implementation.