### PR TITLE
Fix crash when file resource handles files with nameless owner

### DIFF
--- a/mrblib/mitamae/inline_backends/file_backend.rb
+++ b/mrblib/mitamae/inline_backends/file_backend.rb
@@ -30,7 +30,8 @@ module MItamae
       def get_file_owner_user(path)
         uid = File.stat(path).uid
         passwd = Etc.getpwuid(uid)
-        Specinfra::CommandResult.new(stdout: passwd.name, stderr: '', exit_status: 0)
+        result = passwd ? passwd.name : 'UNKNOWN'
+        Specinfra::CommandResult.new(stdout: result, stderr: '', exit_status: 0)
       rescue SystemCallError => e
         Specinfra::CommandResult.new(stdout: '', stderr: e.message, exit_status: 1)
       end
@@ -38,7 +39,8 @@ module MItamae
       def get_file_owner_group(path)
         gid = File.stat(path).gid
         group = Etc.getgrgid(gid)
-        Specinfra::CommandResult.new(stdout: group.name, stderr: '', exit_status: 0)
+        result = group ? group.name : 'UNKNOWN'
+        Specinfra::CommandResult.new(stdout: result, stderr: '', exit_status: 0)
       rescue SystemCallError => e
         Specinfra::CommandResult.new(stdout: '', stderr: e.message, exit_status: 1)
       end


### PR DESCRIPTION
MItamae crashes when the file being manipulated by the `file` resource is owned by a user or a group that does not have their name in the passwd/group database. Itamae does not crash in the same condition (though I don't know it's intended or unintentionally working).

```console
% stat /tmp/test
  File: /tmp/test
  Size: 0               Blocks: 0          IO Block: 4096   regular empty file
Device: 68h/104d        Inode: 29          Links: 1
Access: (0755/-rwxr-xr-x)  Uid: (12345/ UNKNOWN)   Gid: (12345/ UNKNOWN)
Access: 2019-11-28 14:47:28.672696794 +0000
Modify: 2019-11-28 14:45:31.387417648 +0000
Change: 2019-11-28 14:45:31.387417648 +0000
 Birth: -

% cat test.rb
file '/tmp/test' do
  owner 'root'
  group 'root'
end

% mruby/bin/mitamae local test.rb
 INFO : Starting mitamae...
 INFO : Recipe: /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/test.rb
trace (most recent call last):
        [0] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae.rb:2:in __main__
        [1] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/cli.rb:4:in start
        [2] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/cli.rb:17:in run
        [3] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/cli/local.rb:37:in run
        [4] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/recipe_executor.rb:8:in execute
        [5] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mruby/mrblib/array.rb:18:in each
        [6] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/recipe_executor.rb:9:in execute
        [7] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/recipe_executor.rb:19:in execute_node
        [8] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/recipe_executor.rb:33:in execute_children
        [9] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/logger.rb:97:in with_indent
        [10] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/recipe_executor.rb:34:in execute_children
        [11] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mruby/mrblib/array.rb:18:in each
        [12] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/recipe_executor.rb:35:in execute_children
        [13] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/recipe_executor.rb:26:in execute_node
        [14] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/resource_executor/base.rb:13:in execute
        [15] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/logger.rb:106:in with_indent_if
        [16] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/resource_executor/base.rb:16:in execute
        [17] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mruby/mrblib/array.rb:18:in each
        [18] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/resource_executor/base.rb:17:in execute
        [19] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/resource_executor/file.rb:34:in run_action
        [20] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/resource_executor/base.rb:66:in run_action
        [21] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/logger.rb:106:in with_indent_if
        [22] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/resource_executor/base.rb:71:in run_action
        [23] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/resource_executor/base.rb:130:in current_attributes
        [24] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mruby/mrbgems/mruby-object-ext/mrblib/object.rb:16:in tap
        [25] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/resource_executor/base.rb:131:in current_attributes
        [26] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/resource_executor/file.rb:45:in set_current_attributes
        [27] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/resource_executor/base.rb:175:in run_specinfra
        [28] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/inline_backends/file_backend.rb:9:in run
        [29] /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/inline_backends/file_backend.rb:33:in get_file_owner_user
/home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/mrblib/mitamae/inline_backends/file_backend.rb:33: undefined method 'name' (NoMethodError)

% itamae local test.rb
 INFO : Starting Itamae...
 INFO : Recipe: /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/test.rb
 INFO :   file[/tmp/test] owner will change from 'UNKNOWN' to 'root'
 INFO :   file[/tmp/test] group will change from 'UNKNOWN' to 'root'
```

This patch on `InlineBackends::FileBackend` mimics the behavior of specinfra that internally uses `stat -c %U` and `stat -c %G` (on GNU/Linux).

With patch:
```console
% mruby/bin/mitamae local test.rb
 INFO : Starting mitamae...
 INFO : Recipe: /home/kasumi/.local/src/github.com/itamae-kitchen/mitamae/test.rb
 INFO :   file[/tmp/test] owner will change from 'UNKNOWN' to 'root'
 INFO :   file[/tmp/test] group will change from 'UNKNOWN' to 'root'
```