### PR TITLE
file: Supress diff on create

### DIFF
--- a/mrblib/mitamae/resource_executor/file.rb
+++ b/mrblib/mitamae/resource_executor/file.rb
@@ -88,7 +88,7 @@ module MItamae
       def show_differences
         super
 
-        if @temppath && desired.exist
+        if @temppath && current.exist && desired.exist
           show_content_diff
         end
       end


### PR DESCRIPTION
Supress output of content diff on create - in case when the file is not present on filesystem yet.

When large script files are created by remote_file or template resource the current behavior consumes a lot of log lines which is noisy.

~The original itamae behaves the same~ The current behavior has been preserved since [initial implementation][2] and I believe this is not intentional.

[2]: https://github.com/itamae-kitchen/mitamae/commit/65df89cee0882a5892cf197e94787b3f1a2df214