### PR TITLE
bundle mruby-enum-ext

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -7,6 +7,7 @@ MRuby::Gem::Specification.new('mitamae') do |spec|
   spec.summary = 'mitamae'
   spec.bins    = ['mitamae']
 
+  spec.add_dependency 'mruby-enum-ext',    core: 'mruby-enum-ext'
   spec.add_dependency 'mruby-enumerator',  core: 'mruby-enumerator'
   spec.add_dependency 'mruby-eval',        core: 'mruby-eval'
   spec.add_dependency 'mruby-exit',        core: 'mruby-exit'


### PR DESCRIPTION
I'm unsure when mruby-enum-ext was removed from the dependencies (looks like it was a indirect dep), and I noticed methods from enum-ext have disappeared after upgrading my mitamae build.

I believe it is reasonable to bundle mruby-enum-ext as well as other core *-ext mrbgems.