### PR TITLE
Get user encrypted password from /etc/shadow

### DIFF
--- a/mrblib/mitamae/inline_backends/user_backend.rb
+++ b/mrblib/mitamae/inline_backends/user_backend.rb
@@ -40,10 +40,6 @@ module MItamae
       def get_user_login_shell(user_name)
         get_passwd_entry(user_name) { |pw| pw.shell }
       end
-
-      def get_user_encrypted_password(user_name)
-        get_passwd_entry(user_name) { |pw| pw.passwd }
-      end
     end
   end
 end

--- a/spec/integration/user_spec.rb
+++ b/spec/integration/user_spec.rb
@@ -17,4 +17,12 @@ describe 'user resource' do
     it { should be_owned_by 'itamae2' }
     it { should be_grouped_into 'itamae2' }
   end
+
+  describe file('/tmp/itamae3-password-should-not-be-updated') do
+    it { should_not exist }
+  end
+
+  describe file('/tmp/itamae3-password-should-be-updated') do
+    it { should exist }
+  end
 end

--- a/spec/recipes/user.rb
+++ b/spec/recipes/user.rb
@@ -24,3 +24,47 @@ user 'create itamae2 user with create home directory' do
   home '/home/itamae2'
   shell '/bin/sh'
 end
+
+execute 'deluser --remove-home itamae3' do
+  only_if 'id itamae3'
+end
+
+file '/tmp/itamae3-password-should-not-be-updated' do
+  action :delete
+end
+
+file '/tmp/itamae3-password-should-be-updated' do
+  action :delete
+end
+
+# salt: 'salt', password: 'password'
+itamae3_encrypted_password = '$6$salt$IxDD3jeSOb5eB1CX5LBsqZFVkJdido3OUILO5Ifz5iwMuTS4XMS130MTSuDDl3aCI6WouIL9AjRbLCelDCy.g.'
+# salt: 'salt', password: 'password2'
+itamae3_encrypted_password2 = '$6$salt$j48aGM/5GaMl0CCDSihdu1QGIFET5rK.L/ZpznS41s/HgxCe/2sNJ5kU39.gBvsagjQldZ9K8zJg0N.W9zWGp1'
+
+user 'create itamae3 user with password hash' do
+  username 'itamae3'
+  password itamae3_encrypted_password
+end
+
+user 'create itamae3 user with password hash again' do
+  username 'itamae3'
+  password itamae3_encrypted_password
+  notifies :create, 'file[itamae3 password should not be updated]'
+end
+
+user 'change password of itamae3' do
+  username 'itamae3'
+  password itamae3_encrypted_password2
+  notifies :create, 'file[itamae3 password should be updated]'
+end
+
+file 'itamae3 password should not be updated' do
+  action :nothing
+  path '/tmp/itamae3-password-should-not-be-updated'
+end
+
+file 'itamae3 password should be updated' do
+  action :nothing
+  path '/tmp/itamae3-password-should-be-updated'
+end


### PR DESCRIPTION
Currently, mitamae get user information by `Etc.getpwnam()`. That function retrieves data from `/etc/passwd`.
https://www.rubydoc.info/stdlib/etc/Etc.getpwnam
In my environment (Ubuntu 20.04.3), encrypted password is stored in `/etc/shadow`, so `current_password` in user resource returns `'x'` as encrypted password.

There is **no problem to create user and set password** of the user by recipe, but it **falsely detect** that encrypted password differs.

I wrote some tests.

```ruby
# salt: 'salt', password: 'password'
itamae3_encrypted_password = '$6$salt$IxDD3jeSOb5eB1CX5LBsqZFVkJdido3OUILO5Ifz5iwMuTS4XMS130MTSuDDl3aCI6WouIL9AjRbLCelDCy.g.'

user 'create itamae3 user with password hash' do
  username 'itamae3'
  password itamae3_encrypted_password
end

user 'create itamae3 user with password hash again' do
  username 'itamae3'
  password itamae3_encrypted_password
  notifies :create, 'file[itamae3 password should not be updated]'
end
```

```
 INFO :   user[create itamae3 user with password hash] exist will change from 'false' to 'true'
 INFO :   user[create itamae3 user with password hash again] password will change from 'x' to '$6$salt$IxDD3jeSOb5eB1CX5LBsqZFVkJdido3OUILO5Ifz5iwMuTS4XMS130MTSuDDl3aCI6WouIL9AjRbLCelDCy.g.'
 INFO :   Notifying create to file resource 'itamae3 password should not be updated' (delayed)
```

In `mruby-specinfra` (`specinfra`), encrypted password is retrieved with `genent shadow` command, and it is preferable in my environment.

https://github.com/itamae-kitchen/mruby-specinfra/blob/master/mrblib/specinfra/command/1_base/user.rb#L99
https://github.com/mizzy/specinfra/blob/v2.82.25/lib/specinfra/command/base/user.rb#L99

I removed the method defined for mitamae and used specinfra's one. By this, it passed the test above.

I am not sure why you first created user backend for mitamae,
Please check if infraspec version of `get_user_encrypted_password` has no problem now,










