### PR TITLE
Add support for live streaming command output to the console

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ They should be ported to Itamae at some point.
 
 * `not_if` / `only_if` can take a block instead of a command
 * `file`, `remote_file`, and `template` resources have `atomic_update` attribute
+* `run_command` can take `log_output: true`, which will stream the command's
+  output to to the console
 
 ### Plugins
 


### PR DESCRIPTION
This adds a new argument to `run_command`, `stream_output: true`, that
will log output lines to the console as they come in. In addition, if
debug logging is enabled, command output will be streamed instead of
being collected and then printed.