### PR TITLE
Execute local_ruby_block code inside of chdir-ed block if cwd presented

### DIFF
--- a/mrblib/mitamae/resource_executor/local_ruby_block.rb
+++ b/mrblib/mitamae/resource_executor/local_ruby_block.rb
@@ -3,7 +3,13 @@ module MItamae
     class LocalRubyBlock < Base
       def apply
         if desired.executed
-          desired.block.call
+          if desired.cwd
+            Dir.chdir(desired.cwd) do
+              desired.block.call
+            end
+          else
+            desired.block.call
+          end
         end
       end
 

--- a/spec/recipes/local_ruby_block.rb
+++ b/spec/recipes/local_ruby_block.rb
@@ -35,3 +35,12 @@ local_ruby_block 'create /tmp/local_ruby_block_nothing' do
     File.open('/tmp/local_ruby_block_nothing', 'w') {}
   end
 end
+
+local_ruby_block 'test' do
+  cwd "/tmp"
+  block do
+    unless `pwd`.chomp == "/tmp"
+      raise "working directory mismatched"
+    end
+  end
+end


### PR DESCRIPTION
"local_ruby_block" execute by itamae's ruby process. The process doesn't change its working directory, which is presented by "cwd" attribute.
I think it's the root cause of itamae's issue https://github.com/itamae-kitchen/itamae/issues/353

I made the local_ruby_block code execute inside of Dir.chdir block if cwd attribute was presented to fix it.
This behavior has existed since 2015 (in itamae https://github.com/itamae-kitchen/itamae/pull/146, not mitamae).


There might be a recipe that is dependent on current behavior somewhere.
Although I couldn't find public itamae recipes that use "local_ruby_block" with "cwd", the change has a small impact, I think.

ref https://github.com/itamae-kitchen/itamae/pull/355

@k0kubun how do you think?