### PR TITLE
fix host inventory spec

### DIFF
--- a/spec/integration/host_inventory_spec.rb
+++ b/spec/integration/host_inventory_spec.rb
@@ -17,7 +17,7 @@ describe 'host_inventory' do
     cpu: /"cpu_family"/,
     virtualization: /\A{("system"=>(nil|"docker"))?}\z/,
     kernel: /"name"=>"Linux"/,
-    block_device: /\A{}\z/,
+    block_device: /\A{.*}\z/,
     user: /"root"=>{[^{}]*"uid"=>"0", /,
   }.each do |key, expected|
     describe file("/tmp/host_inventory_#{key}") do


### PR DESCRIPTION
block device of host inventory is not empty on version 1.13.1.

failed test: https://github.com/itamae-kitchen/mitamae/runs/7554499967?check_suite_focus=true#step:5:7366

```
  1) host_inventory File "/tmp/host_inventory_block_device" content is expected to match /\A{}\z/
     Failure/Error: its(:content) { should match(expected) }
       expected "{\"loop0\"=>{\"rotational\"=>\"1\", \"removable\"=>\"0\", \"size\"=>\"138880\"}, \"loop1\"=>{\"rotat...300\", \"vendor\"=>\"Msft\", \"rotational\"=>\"1\", \"removable\"=>\"0\", \"size\"=>\"180355072\"}}" to match /\A{}\z/
       Diff:
       @@ -1 +1 @@
       -/\A{}\z/
       +"{\"loop0\"=>{\"rotational\"=>\"1\", \"removable\"=>\"0\", \"size\"=>\"138880\"}, \"loop1\"=>{\"rotational\"=>\"1\", \"removable\"=>\"0\", \"size\"=>\"126824\"}, \"loop2\"=>{\"rotational\"=>\"1\", \"removable\"=>\"0\", \"size\"=>\"96176\"}, \"loop3\"=>{\"rotational\"=>\"1\", \"removable\"=>\"0\", \"size\"=>\"0\"}, \"loop4\"=>{\"rotational\"=>\"1\", \"removable\"=>\"0\", \"size\"=>\"0\"}, \"loop5\"=>{\"rotational\"=>\"1\", \"removable\"=>\"0\", \"size\"=>\"0\"}, \"loop6\"=>{\"rotational\"=>\"1\", \"removable\"=>\"0\", \"size\"=>\"0\"}, \"loop7\"=>{\"rotational\"=>\"1\", \"removable\"=>\"0\", \"size\"=>\"0\"}, \"sda\"=>{\"model\"=>\"Virtual Disk\", \"rev\"=>\"1.0\", \"state\"=>\"running\", \"timeout\"=>\"300\", \"vendor\"=>\"Msft\", \"rotational\"=>\"1\", \"removable\"=>\"0\", \"size\"=>\"29360128\"}, \"sdb\"=>{\"model\"=>\"Virtual Disk\", \"rev\"=>\"1.0\", \"state\"=>\"running\", \"timeout\"=>\"300\", \"vendor\"=>\"Msft\", \"rotational\"=>\"1\", \"removable\"=>\"0\", \"size\"=>\"180355072\"}}"
       
     # ./spec/integration/host_inventory_spec.rb:25:in `block (4 levels) in <top (required)>'

Finished in 3 minutes 24.2 seconds (files took 0.33383 seconds to load)
193 examples, 1 failure
```