### PR TITLE
bump specinfra v2.87.0 from v2.83.3

### DIFF
--- a/build_config.rb.lock
+++ b/build_config.rb.lock
@@ -57,7 +57,7 @@ builds:
     https://github.com/k0kubun/mruby-specinfra.git:
       url: https://github.com/k0kubun/mruby-specinfra.git
       branch: master
-      commit: 2a66b88cf87143b7d0ee8ab28ca3cbd69ad367cf
+      commit: aa98e3e9aa89f9a305cf0f875bfe76a6fff905e6
       version: 0.0.0
     https://github.com/k0kubun/mruby-tempfile.git:
       url: https://github.com/k0kubun/mruby-tempfile.git


### PR DESCRIPTION
This pull request contains:

- Support Amazon Linux 2022 https://github.com/mizzy/specinfra/pull/738
- Replace obsolete File.exists? with File.exist? https://github.com/mizzy/specinfra/pull/739
- Add Guix support https://github.com/mizzy/specinfra/pull/740
- add KDE Neon support https://github.com/mizzy/specinfra/pull/742
- Add VyOS Support https://github.com/mizzy/specinfra/pull/743
- Add support for Amazon Linux 2023 https://github.com/mizzy/specinfra/pull/744

https://github.com/mizzy/specinfra/compare/v2.83.4...v2.87.0 https://github.com/itamae-kitchen/mruby-specinfra/compare/2a66b88cf87143b7d0ee8ab28ca3cbd69ad367cf...aa98e3e9aa89f9a305cf0f875bfe76a6fff905e6