### PR TITLE
fix broken integrated tests

### DIFF
--- a/spec/integration/http_request_spec.rb
+++ b/spec/integration/http_request_spec.rb
@@ -53,7 +53,7 @@ describe 'http_request resource' do
 
   describe file('/tmp/http_request_redirect.html') do
     it { should be_file }
-    its(:content) { should match(/"from": ?"itamae"/) }
+    its(:content) { should match(/"from":\s*\[\s*"itamae"\s*\]/) }
   end
 
   describe file('/tmp/https_request.json') do

--- a/spec/recipes/http_request.rb
+++ b/spec/recipes/http_request.rb
@@ -29,7 +29,7 @@ end
 
 http_request "/tmp/http_request_redirect.html" do
   redirect_limit 1
-  url "http://httpbingo.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fget%3Ffrom%3Ditamae"
+  url "http://httpbingo.org/redirect-to?url=https%3A%2F%2Fhttpbingo.org%2Fget%3Ffrom%3Ditamae"
 end
 
 http_request "/tmp/https_request.json" do


### PR DESCRIPTION
httpbingo.org now checks redirect URLs.

```
% curl 'http://httpbingo.org/redirect-to?url=https%3A%2F%2Fhttpbin.org%2Fget%3Ffrom%3Ditamae'
Forbidden redirect URL. Please be careful with this link.

Allowed redirect destinations:
- example.com
- example.net
- example.org
- httpbingo.org
```

This pull request changes to use allowed URLs