### PR TITLE
Update mruby-specinfra to 2.94.0

### DIFF
--- a/build_config.rb.lock
+++ b/build_config.rb.lock
@@ -57,7 +57,7 @@ builds:
     https://github.com/k0kubun/mruby-specinfra.git:
       url: https://github.com/k0kubun/mruby-specinfra.git
       branch: master
-      commit: 133975a79e968c35ec23bc0dc24b7dd7e79c9d29
+      commit: d6d0fda00c3f099b346a73a43cda53f03ed32a2e
       version: 0.0.0
     https://github.com/k0kubun/mruby-tempfile.git:
       url: https://github.com/k0kubun/mruby-tempfile.git


### PR DESCRIPTION
This pull request contains:

- [Clear BUNDLER_SETUP env in exec #757](https://github.com/mizzy/specinfra/pull/757)
- [Detect Debian Testing and assign a impossibly high version number #758](https://github.com/mizzy/specinfra/pull/758)
- [feat: Add platform_codename host inventory #759](https://github.com/mizzy/specinfra/pull/759)

List of changes:

- [mizzy/specinfra@v2.91.0...v2.94.0](https://github.com/mizzy/specinfra/compare/v2.91.0...v2.94.0)
- [itamae-kitchen/mruby-specinfra@133975a...d6d0fda](https://github.com/itamae-kitchen/mruby-specinfra/compare/133975a79e968c35ec23bc0dc24b7dd7e79c9d29...d6d0fda00c3f099b346a73a43cda53f03ed32a2e)