### PR TITLE
Enable GitHub Artifact Attestations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for provenances
+      attestations: write # for provenances
     strategy:
       matrix:
         include:
@@ -52,6 +55,11 @@ jobs:
           version: 0.9.1
       - name: Build ${{ matrix.os }}-${{ matrix.arch }} binary
         run: bundle exec rake release:build:${{ matrix.os }}-${{ matrix.arch }} release:compress
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'mitamae-build/**'
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Sign build artifacts in GitHub Actions workflow to provide verifiable origins for the artifacts.

See also:

- GitHub Artifact Attestations is generally available
  - https://github.blog/changelog/2024-06-25-artifact-attestations-is-generally-available/
- GitHub Action: `actions/attest-build-provenance@v2`
  - https://github.com/actions/attest-build-provenance