### PR TITLE
Generate GitHub Artifact Attestations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,10 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for uses: actions/checkout
+      id-token: write # for uses: aactions/attest-build-provenance
+      attestations: write # for uses: aactions/attest-build-provenance
     strategy:
       matrix:
         include:
@@ -53,6 +57,11 @@ jobs:
           version: 0.9.1
       - name: Build ${{ matrix.os }}-${{ matrix.arch }} binary
         run: bundle exec rake release:build:${{ matrix.os }}-${{ matrix.arch }} release:compress
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: mitamae-build/mitamae-*
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Sign build artifacts in GitHub Actions workflow to provide verifiable origins for the artifacts.

See also:

- GitHub Artifact Attestations is generally available
  - https://github.blog/changelog/2024-06-25-artifact-attestations-is-generally-available/
- GitHub Action: `actions/attest-build-provenance@v2`
  - https://github.com/actions/attest-build-provenance