### PR TITLE
Limit artifact attestation to push events on trusted refs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,12 +60,7 @@ jobs:
 
       - name: Generate artifact attestation
         # Since the necessary permissions cannot be set in the pull_request event, it is limited to push events.
-        if: >-
-          ${{
-            github.ref == 'refs/heads/master' ||
-            startsWith(github.ref, 'refs/heads/build-') ||
-            startsWith(github.ref, 'refs/tags/')
-          }}
+        if: ${{ !startsWith(github.event_name, 'pull') }}
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: mitamae-build/mitamae-*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,13 @@ jobs:
         run: bundle exec rake release:build:${{ matrix.os }}-${{ matrix.arch }} release:compress
 
       - name: Generate artifact attestation
+        # Since the necessary permissions cannot be set in the pull_request event, it is limited to push events.
+        if: >-
+          ${{
+            github.ref == 'refs/heads/master' ||
+            startsWith(github.ref, 'refs/heads/build-') ||
+            startsWith(github.ref, 'refs/tags/')
+          }}
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: mitamae-build/mitamae-*


### PR DESCRIPTION
Artifact attestation using `actions/attest-build-provenance` requires appropriate permissions (OIDC token and secrets), which are not available in `pull_request` events for security reasons.

This commit restricts the attestation step to only run on:

- `master` branch
- `build-*` branches
- `tag` refs (`refs/tags/*`)

This ensures provenance attestation is only generated during trusted build contexts.

Related PR:
- https://github.com/itamae-kitchen/mitamae/pull/137