### PR TITLE
Cross-compile to OpenBSD with zig

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
           ruby-version: '3.0'
           bundler-cache: true
 
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: mlugg/setup-zig@v2
         with:
-          version: 0.9.1
+          version: 0.16.0-dev.2193+fc517bd01
       - name: Integration test
         run: bundle exec rake test:integration
 
@@ -52,9 +52,9 @@ jobs:
           ruby-version: '3.0'
           bundler-cache: true
 
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: mlugg/setup-zig@v2
         with:
-          version: 0.9.1
+          version: 0.16.0-dev.2193+fc517bd01
       - name: Build ${{ matrix.os }}-${{ matrix.arch }} binary
         run: bundle exec rake release:build:${{ matrix.os }}-${{ matrix.arch }} release:compress
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,12 +38,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: linux,  arch: x86_64 }
-          - { os: linux,  arch: i386 }
-          - { os: linux,  arch: armhf }
-          - { os: linux,  arch: aarch64 }
-          - { os: darwin, arch: x86_64 }
-          - { os: darwin, arch: aarch64 }
+          - { os: linux,   arch: x86_64 }
+          - { os: linux,   arch: i386 }
+          - { os: linux,   arch: armhf }
+          - { os: linux,   arch: aarch64 }
+          - { os: darwin,  arch: x86_64 }
+          - { os: darwin,  arch: aarch64 }
+          - { os: openbsd, arch: x86_64 }
+          - { os: openbsd, arch: aarch64 }
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -154,6 +156,15 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: mitamae-aarch64-darwin
+          path: mitamae-build/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: mitamae-aarch64-openbsd
+          path: mitamae-build/
+      - uses: actions/download-artifact@v4
+        with:
+          name: mitamae-x86_64-openbsd
           path: mitamae-build/
 
       - uses: actions/download-artifact@v4

--- a/Rakefile
+++ b/Rakefile
@@ -51,6 +51,8 @@ CROSS_TARGETS = %w[
   linux-i386
   linux-armhf
   linux-aarch64
+  openbsd-x86_64
+  openbsd-aarch64
   darwin-x86_64
   darwin-aarch64
 ]

--- a/build_config.rb
+++ b/build_config.rb
@@ -139,3 +139,37 @@ if build_targets.include?('darwin-aarch64')
     gem_config(conf)
   end
 end
+
+if build_targets.include?('openbsd-x86_64')
+  MRuby::CrossBuild.new('openbsd-x86_64') do |conf|
+    toolchain :gcc
+
+    [conf.cc, conf.linker].each do |cc|
+      cc.command = 'zig cc -target x86_64-openbsd-none'
+    end
+    conf.archiver.command = 'zig ar'
+    ENV['RANLIB'] ||= 'zig ranlib'
+
+    conf.host_target = 'x86_64-linux'
+
+    debug_config(conf)
+    gem_config(conf)
+  end
+end
+
+if build_targets.include?('openbsd-aarch64')
+  MRuby::CrossBuild.new('openbsd-aarch64') do |conf|
+    toolchain :gcc
+
+    [conf.cc, conf.linker].each do |cc|
+      cc.command = 'zig cc -target aarch64-openbsd-none'
+    end
+    conf.archiver.command = 'zig ar'
+    ENV['RANLIB'] ||= 'zig ranlib'
+
+    conf.host_target = 'aarch64-linux'
+
+    debug_config(conf)
+    gem_config(conf)
+  end
+end


### PR DESCRIPTION
Hello, So, three things happened.

First, i found mitamae and happily started using it on my openbsd machines instead of ansible. Thank you for this.

Second, upstream OpenBSD bumped libc major version, so published openbsd binary fails to start:

```
# ftp -V https://github.com/itamae-kitchen/mitamae-build/releases/download/v1.14.4/mitamae-x86_64-openbsd 
9b8be232-f3c6-4299-911... 100% |************************| 10095 KB    00:00  
# ldd mitamae-x86_64-openbsd                                                                                                                                                                       
mitamae-x86_64-openbsd:
ld.so: mitamae-x86_64-openbsd: can't load library 'libpthread.so.27.1'
mitamae-x86_64-openbsd: signal 9
# ./mitamae-x86_64-openbsd                                                                                                                                                                         
ld.so: mitamae-x86_64-openbsd: can't load library 'libc.so.100.3'
Killed 
```

I've been thinking about packaging mitaame as a proper port, when third thing happened - zig announced support for cross-compiling for openbsd. Given that it is already used for compiling to macos, i tried to run with default configuration - and it worked!

https://github.com/pzskc383/mitamae/actions/runs/20989228076 - you can get built artifacts for openbsd on aarch64 and amd64 from my run.

I'm marking this PR as a drafrt because, while i already use built binaries, i haven't run full test suite yet. And you might want to extend targets to, say, freebsd too.

Hope this helps and thanks again for this software.
