### PR TITLE
Ci improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ on:
     - cron: "30 15 * * *" # 7:30 PST (-8), 8:30 PDT (-7)
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && contains(github.ref,'v*')) }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -61,6 +65,7 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.16.0
+
       - name: Build ${{ matrix.os }}-${{ matrix.arch }} binary
         run: bundle exec rake release:build:${{ matrix.os }}-${{ matrix.arch }} release:compress
 
@@ -76,14 +81,14 @@ jobs:
         with:
           name: mitamae-${{ matrix.arch }}-${{ matrix.os }}
           path: mitamae-build/
+          retention-days: 30
 
   checksum:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # for uses: aactions/attest-build-provenance
       attestations: write # for uses: aactions/attest-build-provenance
-    needs:
-      - build
+    needs: [build]
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -131,73 +136,24 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs:
-      - test
-      - build
-      - checksum
+    needs: [test, build, checksum]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: mitamae-x86_64-linux
-          path: mitamae-build/
-      - uses: actions/download-artifact@v4
-        with:
-          name: mitamae-i386-linux
-          path: mitamae-build/
-      - uses: actions/download-artifact@v4
-        with:
-          name: mitamae-armhf-linux
-          path: mitamae-build/
-      - uses: actions/download-artifact@v4
-        with:
-          name: mitamae-aarch64-linux
-          path: mitamae-build/
-      - uses: actions/download-artifact@v4
-        with:
-          name: mitamae-s390x-linux
-          path: mitamae-build/
-      - uses: actions/download-artifact@v4
-        with:
-          name: mitamae-ppc64le-linux
-          path: mitamae-build/
-      - uses: actions/download-artifact@v4
-        with:
-          name: mitamae-x86_64-darwin
-          path: mitamae-build/
-      - uses: actions/download-artifact@v4
-        with:
-          name: mitamae-aarch64-darwin
-          path: mitamae-build/
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: mitamae-aarch64-freebsd
-          path: mitamae-build/
-      - uses: actions/download-artifact@v4
-        with:
-          name: mitamae-x86_64-freebsd
-          path: mitamae-build/
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: mitamae-aarch64-openbsd
-          path: mitamae-build/
-      - uses: actions/download-artifact@v4
-        with:
-          name: mitamae-x86_64-openbsd
-          path: mitamae-build/
-
+          path: release-assets/
+          pattern: mitamae-*
+          merge-multiple: true
       - uses: actions/download-artifact@v4
         with:
           name: checksum-sha256sums
-          path: mitamae-build/
-
-      - name: Release
-        run: |
-          export VERSION=$(echo "$GITHUB_REF" | sed -e 's!refs/tags/!!')
-          curl -L "https://github.com/tcnksm/ghr/releases/download/${GHR_VERSION}/ghr_${GHR_VERSION}_linux_amd64.tar.gz" | tar xvz
-          "ghr_${GHR_VERSION}_linux_amd64/ghr" -u itamae-kitchen -r mitamae -replace -n "$VERSION" "$VERSION" mitamae-build/
+          path: release-assets/
+      - name: Create Release
         env:
-          GHR_VERSION: v0.13.0
-          GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --generate-notes \
+            release-assets/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
           ruby-version: '3.0'
           bundler-cache: true
 
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: mlugg/setup-zig@v2
         with:
-          version: 0.9.1
+          version: 0.16.0
       - name: Integration test
         run: bundle exec rake test:integration
 
@@ -38,12 +38,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: linux,  arch: x86_64 }
-          - { os: linux,  arch: i386 }
-          - { os: linux,  arch: armhf }
-          - { os: linux,  arch: aarch64 }
-          - { os: darwin, arch: x86_64 }
-          - { os: darwin, arch: aarch64 }
+          - { os: linux,   arch: x86_64 }
+          - { os: linux,   arch: i386 }
+          - { os: linux,   arch: armhf }
+          - { os: linux,   arch: aarch64 }
+          - { os: linux,   arch: s390x }
+          - { os: linux,   arch: ppc64le }
+          - { os: darwin,  arch: x86_64 }
+          - { os: darwin,  arch: aarch64 }
+          - { os: freebsd, arch: x86_64 }
+          - { os: freebsd, arch: aarch64 }
+          - { os: openbsd, arch: x86_64 }
+          - { os: openbsd, arch: aarch64 }
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -52,9 +58,9 @@ jobs:
           ruby-version: '3.0'
           bundler-cache: true
 
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: mlugg/setup-zig@v2
         with:
-          version: 0.9.1
+          version: 0.16.0
       - name: Build ${{ matrix.os }}-${{ matrix.arch }} binary
         run: bundle exec rake release:build:${{ matrix.os }}-${{ matrix.arch }} release:compress
 
@@ -149,11 +155,37 @@ jobs:
           path: mitamae-build/
       - uses: actions/download-artifact@v4
         with:
+          name: mitamae-s390x-linux
+          path: mitamae-build/
+      - uses: actions/download-artifact@v4
+        with:
+          name: mitamae-ppc64le-linux
+          path: mitamae-build/
+      - uses: actions/download-artifact@v4
+        with:
           name: mitamae-x86_64-darwin
           path: mitamae-build/
       - uses: actions/download-artifact@v4
         with:
           name: mitamae-aarch64-darwin
+          path: mitamae-build/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: mitamae-aarch64-freebsd
+          path: mitamae-build/
+      - uses: actions/download-artifact@v4
+        with:
+          name: mitamae-x86_64-freebsd
+          path: mitamae-build/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: mitamae-aarch64-openbsd
+          path: mitamae-build/
+      - uses: actions/download-artifact@v4
+        with:
+          name: mitamae-x86_64-openbsd
           path: mitamae-build/
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,10 @@ jobs:
           ruby-version: '3.0'
           bundler-cache: true
 
+      - uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "14"
+
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v2.0.0
+## v1.15.0
 
 - Bump mruby version from 3.0.0 to 3.4.0
 

--- a/Rakefile
+++ b/Rakefile
@@ -27,11 +27,6 @@ CROSS_TARGETS = %w[
   darwin-aarch64
 ].freeze
 
-STRIP_TARGETS = %w[
-  linux-x86_64
-  linux-i386
-]
-
 # avoid redefining constants in mruby Rakefile
 mruby_root = File.expand_path(ENV['MRUBY_ROOT'] || "#{Dir.pwd}/mruby")
 mruby_config = File.expand_path(ENV['MRUBY_CONFIG'] || 'build_config.rb')
@@ -72,20 +67,18 @@ CROSS_TARGETS.each do |target|
       FileUtils.mkdir_p('mitamae-build')
       os, arch = target.split('-', 2)
       bin = "mitamae-build/mitamae-#{arch}-#{os}"
-      sh "cp mruby/build/#{target.shellescape}/bin/mitamae #{bin.shellescape}"
 
-      if STRIP_TARGETS.include?(target)
-        sh "strip --strip-unneeded #{bin.shellescape}"
-      end
+      sh "cp mruby/build/#{target.shellescape}/bin/mitamae #{bin.shellescape}.debug"
+      sh "llvm-strip #{bin.shellescape}.debug -o #{bin.shellescape}"
     end
   end
 end
 
-desc 'compress binaries in mitamae-build'
+desc 'compress debug binaries in mitamae-build'
 task 'release:compress' do
   Dir.chdir(File.expand_path('./mitamae-build', __dir__)) do
-    Dir.glob('mitamae-*').each do |path|
-      sh "tar zcvf #{path}.tar.gz #{path}"
+    Dir.glob('mitamae-*.debug').each do |path|
+      sh "gzip -9 #{path}"
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -17,9 +17,15 @@ CROSS_TARGETS = %w[
   linux-i386
   linux-armhf
   linux-aarch64
+  linux-ppc64le
+  linux-s390x
+  freebsd-x86_64
+  freebsd-aarch64
+  openbsd-x86_64
+  openbsd-aarch64
   darwin-x86_64
   darwin-aarch64
-]
+].freeze
 
 STRIP_TARGETS = %w[
   linux-x86_64

--- a/build_config.rb
+++ b/build_config.rb
@@ -1,3 +1,6 @@
+MACOS_SDK= File.expand_path('./MacOSX.sdk', __dir__)
+MACOS_SDK_VER = "11.3"
+
 def gem_config(conf)
   conf.gem File.expand_path(File.dirname(__FILE__))
 end
@@ -11,15 +14,27 @@ def debug_config(conf)
 end
 
 def download_macos_sdk(path)
-  version = '11.3'
-  system('wget', "https://github.com/phracker/MacOSX-SDKs/releases/download/#{version}/MacOSX#{version}.sdk.tar.xz", exception: true)
-  system('tar', 'xf', "MacOSX#{version}.sdk.tar.xz", exception: true)
-  system('rm', "MacOSX#{version}.sdk.tar.xz", exception: true)
-  system('mv', "MacOSX#{version}.sdk", path, exception: true)
+  system('wget', "https://github.com/phracker/MacOSX-SDKs/releases/download/#{MACOS_SDK_VER}/MacOSX#{MACOS_SDK_VER}.sdk.tar.xz", exception: true)
+  system('tar', 'xf', "MacOSX#{MACOS_SDK_VER}.sdk.tar.xz", exception: true)
+  system('rm', "MacOSX#{MACOS_SDK_VER}.sdk.tar.xz", exception: true)
+  system('mv', "MacOSX#{MACOS_SDK_VER}.sdk", path, exception: true)
 end
 
-macos_sdk = File.expand_path('./MacOSX.sdk', __dir__)
-build_targets = ENV.fetch('BUILD_TARGET', '').split(',')
+TRIPLETS = {
+  'linux-x86_64' => 'x86_64-linux-musl',
+  'linux-i386' => 'x86-linux-musl',
+  'linux-armhf' => 'arm-linux-musleabihf',
+  'linux-aarch64' => 'aarch64-linux-musl',
+  'linux-ppc64le' => 'powerpc64le-linux-musl',
+  'linux-s390x' => 's390x-linux-musl',
+  'darwin-x86_64' => 'x86_64-macos-none',
+  'darwin-aarch64' => 'aarch64-macos-none',
+  'freebsd-x86_64' => 'x86_64-freebsd-none',
+  'freebsd-aarch64' => 'aarch64-freebsd-none',
+  'openbsd-x86_64' => 'x86_64-openbsd-none',
+  'openbsd-aarch64' => 'aarch64-openbsd-none'
+}.freeze
+
 
 # mruby's build system always requires to run host build for mrbc
 MRuby::Build.new do |conf|
@@ -33,107 +48,33 @@ MRuby::Build.new do |conf|
   gem_config(conf)
 end
 
-if build_targets.include?('linux-x86_64')
-  MRuby::Build.new('linux-x86_64') do |conf|
+build_targets = ENV.fetch('BUILD_TARGET', '').split(',')
+CROSS_TARGETS.each do |target|
+  next unless build_targets.include?(target)
+
+  MRuby::CrossBuild.new(target) do |conf|
     toolchain :gcc
+
+    conf.host_target = TRIPLETS[target]
 
     [conf.cc, conf.linker].each do |cc|
-      cc.command = 'zig cc -target x86_64-linux-musl'
+      cc.command = "zig cc -target #{TRIPLETS[target]}"
     end
     conf.archiver.command = 'zig ar'
+    ENV['RANLIB'] ||= 'zig ranlib' unless target.include?('linux')
 
-    debug_config(conf)
-    gem_config(conf)
-  end
-end
+    if target.include?('darwin')
+      macosx_min_ver = target.include?('aarch64') ? '11.1' : '10.14'
+      unless Dir.exist?(MACOS_SDK)
+        download_macos_sdk(MACOS_SDK)
+      end
 
-if build_targets.include?('linux-i386')
-  MRuby::CrossBuild.new('linux-i386') do |conf|
-    toolchain :gcc
-
-    [conf.cc, conf.linker].each do |cc|
-      cc.command = 'zig cc -target i386-linux-musl'
+      conf.cc.command += " -mmacosx-version-min=#{macosx_min_ver} -isysroot #{MACOS_SDK.shellescape}"
+      conf.cc.command += " -iwithsysroot /usr/include -iframeworkwithsysroot /System/Library/Frameworks"
+      conf.linker.command += " -mmacosx-version-min=#{macosx_min_ver} --sysroot #{MACOS_SDK.shellescape}"
+      conf.linker.command += " -F/System/Library/Frameworks -L/usr/lib"
+    else
     end
-    conf.archiver.command = 'zig ar'
-
-    # To configure: mrbgems/mruby-yaml, k0kubun/mruby-onig-regexp
-    conf.host_target = 'i386-pc-linux-gnu'
-
-    debug_config(conf)
-    gem_config(conf)
-  end
-end
-
-if build_targets.include?('linux-armhf')
-  MRuby::CrossBuild.new('linux-armhf') do |conf|
-    toolchain :gcc
-
-    [conf.cc, conf.linker].each do |cc|
-      cc.command = 'zig cc -target arm-linux-musleabihf'
-    end
-    conf.archiver.command = 'zig ar'
-
-    # To configure: mrbgems/mruby-yaml, k0kubun/mruby-onig-regexp
-    conf.host_target = 'arm-linux-musleabihf'
-
-    debug_config(conf)
-    gem_config(conf)
-  end
-end
-
-if build_targets.include?('linux-aarch64')
-  MRuby::CrossBuild.new('linux-aarch64') do |conf|
-    toolchain :gcc
-
-    [conf.cc, conf.linker].each do |cc|
-      cc.command = 'zig cc -target aarch64-linux-musl'
-    end
-    conf.archiver.command = 'zig ar'
-
-    # To configure: mrbgems/mruby-yaml, k0kubun/mruby-onig-regexp
-    conf.host_target = 'aarch64-linux-musl'
-
-    debug_config(conf)
-    gem_config(conf)
-  end
-end
-
-if build_targets.include?('darwin-x86_64')
-  MRuby::CrossBuild.new('darwin-x86_64') do |conf|
-    toolchain :gcc
-
-    unless Dir.exist?(macos_sdk)
-      download_macos_sdk(macos_sdk)
-    end
-
-    conf.cc.command = "zig cc -target x86_64-macos -mmacosx-version-min=10.14 -isysroot #{macos_sdk.shellescape} -iwithsysroot /usr/include -iframeworkwithsysroot /System/Library/Frameworks"
-    conf.linker.command = "zig cc -target x86_64-macos -mmacosx-version-min=10.4 --sysroot #{macos_sdk.shellescape} -F/System/Library/Frameworks -L/usr/lib"
-    conf.archiver.command = 'zig ar'
-    ENV['RANLIB'] ||= 'zig ranlib'
-
-    # To configure: mrbgems/mruby-yaml, k0kubun/mruby-onig-regexp
-    conf.host_target = 'x86_64-darwin'
-
-    debug_config(conf)
-    gem_config(conf)
-  end
-end
-
-if build_targets.include?('darwin-aarch64')
-  MRuby::CrossBuild.new('darwin-aarch64') do |conf|
-    toolchain :gcc
-
-    unless Dir.exist?(macos_sdk)
-      download_macos_sdk(macos_sdk)
-    end
-
-    conf.cc.command = "zig cc -target aarch64-macos -mmacosx-version-min=11.1 -isysroot #{macos_sdk.shellescape} -iwithsysroot /usr/include -iframeworkwithsysroot /System/Library/Frameworks"
-    conf.linker.command = "zig cc -target aarch64-macos -mmacosx-version-min=11.1 --sysroot #{macos_sdk.shellescape} -F/System/Library/Frameworks -L/usr/lib"
-    conf.archiver.command = 'zig ar'
-    ENV['RANLIB'] ||= 'zig ranlib'
-
-    # To configure: mrbgems/mruby-yaml, k0kubun/mruby-onig-regexp
-    conf.host_target = 'aarch64-darwin'
 
     debug_config(conf)
     gem_config(conf)


### PR DESCRIPTION
Hello again, i've noticed you updated mruby to 3.4 and decided to update my PR increasing number of platforms built on CI.

four commits in this pr:

49df19ee7e4403820dbe660660ec4d81af00b7d8 - (minor) fixes v1.15.0 vs v2.0.0 version difference, otherwise tests are failing.

b80e6de5a463f69d61dd23f46bcb46ebcff0ebb7 - adds more platform support via using zig as crosscompiler. that should be all platform available in mitamae-build repo, except sparc-solaris10 (no support from zig, as a simple reason). different configs compypasted for every platform now are set in a single block. some notes on implementation - since every mruby build target except native now works through crossbuild, we link them all statically and that's why linux triplets are all musl. otherwise build behaviour remained pretty much the same.

934954a87b52b8c6b172bdf3bf37d361373c1e5c - small updates for github action workflow - consolidate release job, use official bundled gh cli, concurrency tweaks.

ca925964bf46cd33f1a5246343e75571d136cca4 - adds support for stripping any binary with llvm. also, package an unstripped binary with .debug suffix (gets gz-compressed). before build had list of archis that should be stripped, because strip pfrom GNU binutils can't work on foreign architectures. I tried using zig objcopy -S but it doesn't support Mach-O binaries. So, we add llvm and use llvm-strip which worked on every build target.

there's still some things that bugging me in build system:
- oniguruma rebuild issue, something about presyms that makes second build in same source tree fail, unless you clean it completely.
- habit of mruby build system of using own gem set for every cross-target, so it clones it for every build. we might cut a lot of CI time by packaging needed mrgems in a single zip as an interemediate build step.
- `gem_package` test should use dummy packages instead of upstream rubygems - it would be faster and more robust, not being depended on rubygems.org, right now gem_package spec is the longest test in the suite because of that.
i might return with the fixes if i must enough free time and will.

and thanks for this software and your work in keeping it current with mruby. I tried to do same, but gave up after having to update/patch a bit too many mrbgems. also, i wasn't sure that module_function hiding method visibility isn't a regression. so, thanks again.

hope this helps!