### PR TITLE
bump the actions of GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0'
@@ -56,7 +56,7 @@ jobs:
           - { os: openbsd, arch: aarch64 }
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0'
@@ -76,12 +76,12 @@ jobs:
       - name: Generate artifact attestation
         # Since the necessary permissions cannot be set in the pull_request event, it is limited to push events.
         if: ${{ !startsWith(github.event_name, 'pull') }}
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: mitamae-build/mitamae-*
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mitamae-${{ matrix.arch }}-${{ matrix.os }}
           path: mitamae-build/
@@ -94,7 +94,7 @@ jobs:
       attestations: write # for uses: aactions/attest-build-provenance
     needs: [build]
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: mitamae-build/
           pattern: mitamae-*
@@ -128,12 +128,12 @@ jobs:
       - name: Generate artifact attestation
         # Since the necessary permissions cannot be set in the pull_request event, it is limited to push events.
         if: ${{ !startsWith(github.event_name, 'pull') }}
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: mitamae-build/SHA256SUMS
 
       - name: Upload checksum
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: checksum-sha256sums
           path: mitamae-build/SHA256SUMS
@@ -143,12 +143,12 @@ jobs:
     needs: [test, build, checksum]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: release-assets/
           pattern: mitamae-*
           merge-multiple: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: checksum-sha256sums
           path: release-assets/


### PR DESCRIPTION
fixes warnings: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/attest-build-provenance/predicate@1176ef556905f349f669722abf30bce1a6e16e01, actions/attest@ce27ba3b4a9a139d9a20a4a07d69fabb52f1e5bc, actions/checkout@v4, actions/upload-artifact@v4, KyleMayes/install-llvm-action@v2, mlugg/setup-zig@v2. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Note: The remaining warnings for `KyleMayes/install-llvm-action@v2` and `mlugg/setup-zig@v2` cannot be resolved in this PR — both upstreams' latest releases (install-llvm-action v2.0.9 and setup-zig v2.2.1) still declare `using: 'node20'` in their `action.yml`, and no Node.js 24 compatible release is available yet.