### PR TITLE
Serve httpbin ourselves in http_request specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ghr
 *.zip
 /mruby
 /MacOSX.sdk
+/spec/tmp/

--- a/spec/integration/http_request_spec.rb
+++ b/spec/integration/http_request_spec.rb
@@ -22,33 +22,33 @@ describe 'http_request resource' do
 
   describe file('/tmp/http_request.html') do
     it { should be_file }
-    its(:content) { should match(/"from": ?"itamae"/) }
+    its(:content) { should match(/"from":\s*\[\s*"itamae"\s*\]/) }
   end
 
   describe file('/tmp/http_request_delete.html') do
     it { should be_file }
-    its(:content) { should match(/"from": ?"itamae"/) }
+    its(:content) { should match(/"from":\s*\[\s*"itamae"\s*\]/) }
   end
 
   describe file('/tmp/http_request_post.html') do
     it { should be_file }
     its(:content) do
-      should match(/"from": ?"itamae"/)
-      should match(/"love": ?"sushi"/)
+      should match(/"from":\s*\[\s*"itamae"\s*\]/)
+      should match(/"love":\s*\[\s*"sushi"\s*\]/)
     end
   end
 
   describe file('/tmp/http_request_put.html') do
     it { should be_file }
     its(:content) do
-      should match(/"from": ?"itamae"/)
-      should match(/"love": ?"sushi"/)
+      should match(/"from":\s*\[\s*"itamae"\s*\]/)
+      should match(/"love":\s*\[\s*"sushi"\s*\]/)
     end
   end
 
   describe file('/tmp/http_request_headers.html') do
     it { should be_file }
-    its(:content) { should match(/"User-Agent": ?"Itamae"/) }
+    its(:content) { should match(/"User-Agent":\s*\[\s*"Itamae"\s*\]/) }
   end
 
   describe file('/tmp/http_request_redirect.html') do
@@ -58,6 +58,6 @@ describe 'http_request resource' do
 
   describe file('/tmp/https_request.json') do
     it { should be_file }
-    its(:content) { should match(/"from": ?"itamae"/) }
+    its(:content) { should match(/"from":\s*\[\s*"itamae"\s*\]/) }
   end
 end

--- a/spec/recipes/http_request.rb
+++ b/spec/recipes/http_request.rb
@@ -2,36 +2,36 @@ execute 'apt-get update' # for installing curl
 package 'curl'
 
 http_request "/tmp/http_request.html" do
-  url "http://httpbin.org/get?from=itamae"
+  url "http://httpbin:8080/get?from=itamae"
 end
 
 http_request "/tmp/http_request_delete.html" do
   action :delete
-  url "http://httpbin.org/delete?from=itamae"
+  url "http://httpbin:8080/delete?from=itamae"
 end
 
 http_request "/tmp/http_request_post.html" do
   action :post
   message "love=sushi"
-  url "http://httpbin.org/post?from=itamae"
+  url "http://httpbin:8080/post?from=itamae"
 end
 
 http_request "/tmp/http_request_put.html" do
   action :put
   message "love=sushi"
-  url "http://httpbin.org/put?from=itamae"
+  url "http://httpbin:8080/put?from=itamae"
 end
 
 http_request "/tmp/http_request_headers.html" do
   headers "User-Agent" => "Itamae"
-  url "http://httpbin.org/get"
+  url "http://httpbin:8080/get"
 end
 
 http_request "/tmp/http_request_redirect.html" do
   redirect_limit 1
-  url "http://httpbingo.org/redirect-to?url=https%3A%2F%2Fhttpbingo.org%2Fget%3Ffrom%3Ditamae"
+  url "http://httpbin:8080/redirect-to?url=http%3A%2F%2Fhttpbin%3A8080%2Fget%3Ffrom%3Ditamae"
 end
 
 http_request "/tmp/https_request.json" do
-  url "https://httpbin.org/get?from=itamae"
+  url "https://httpbin-tls:8443/get?from=itamae"
 end

--- a/spec/recipes/http_request_client_error.rb
+++ b/spec/recipes/http_request_client_error.rb
@@ -2,5 +2,5 @@ execute 'apt-get update' # for installing curl
 package 'curl'
 
 http_request "/tmp/http_request_client_error.html" do
-  url "http://httpbin.org/status/400?from=itamae"
+  url "http://httpbin:8080/status/400?from=itamae"
 end

--- a/spec/recipes/http_request_redirect_limit.rb
+++ b/spec/recipes/http_request_redirect_limit.rb
@@ -3,5 +3,5 @@ package 'curl'
 
 http_request "/tmp/http_request_redirect_limit.html" do
   redirect_limit 1
-  url "http://httpbin.org/absolute-redirect/3?from=itamae"
+  url "http://httpbin:8080/absolute-redirect/3?from=itamae"
 end

--- a/spec/recipes/http_request_server_error.rb
+++ b/spec/recipes/http_request_server_error.rb
@@ -2,5 +2,5 @@ execute 'apt-get update' # for installing curl
 package 'curl'
 
 http_request "/tmp/http_request_server_error.html" do
-  url "http://httpbin.org/status/500?from=itamae"
+  url "http://httpbin:8080/status/500?from=itamae"
 end

--- a/spec/recipes/http_request_unknown_error.rb
+++ b/spec/recipes/http_request_unknown_error.rb
@@ -1,6 +1,9 @@
 execute 'apt-get update' # for installing curl
 package 'curl'
 
+# go-httpbin rejects `/status/999` with 400, which is indistinguishable from an ordinary client
+# error. Hitting a port nobody listens on makes curl fail with 7 instead, which is neither a 4xx
+# nor a 5xx and therefore keeps exercising the "unknown error" branch.
 http_request "/tmp/http_request_unknown_error.html" do
-  url "http://httpbin.org/status/999?from=itamae"
+  url "http://httpbin:9"
 end

--- a/spec/recipes/http_request_without_curl.rb
+++ b/spec/recipes/http_request_without_curl.rb
@@ -1,3 +1,3 @@
 http_request "/tmp/http_request.html" do
-  url "http://httpbin.org/get?from=itamae"
+  url "http://httpbin:8080/get?from=itamae"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,72 @@
+require 'fileutils'
 require 'serverspec'
 
 module MItamaeSpec
   TARGET = 'linux-x86_64'
+  # Serving the httpbin API ourselves keeps the http_request specs from depending on a third-party service.
+  HTTPBIN_IMAGE = 'ghcr.io/mccutchen/go-httpbin:2.24.0'
 
-  def self.container
-    @container ||= ENV.fetch('DOCKER_CONTAINER', 'mitamae-serverspec')
+  class << self
+    def container
+      @container ||= ENV.fetch('DOCKER_CONTAINER', 'mitamae-serverspec')
+    end
+
+    def network
+      "#{container}-net"
+    end
+
+    def httpbin
+      "#{container}-httpbin"
+    end
+
+    def httpbin_tls
+      "#{container}-httpbin-tls"
+    end
+
+    def cert_dir
+      File.expand_path('spec/tmp/certs')
+    end
+
+    # The recipes reach go-httpbin by its network alias, so the certificate must be issued for that name.
+    def generate_certificate
+      FileUtils.rm_rf(cert_dir)
+      FileUtils.mkdir_p(cert_dir)
+      system(
+        'openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-days', '365',
+        '-subj', '/CN=httpbin-tls', '-addext', 'subjectAltName=DNS:httpbin-tls',
+        '-keyout', "#{cert_dir}/key.pem", '-out', "#{cert_dir}/cert.pem",
+        out: File::NULL, err: File::NULL, exception: true,
+      )
+      # The go-httpbin image runs as a non-root user, so the mounted files have to be world-readable.
+      FileUtils.chmod(0o644, ["#{cert_dir}/cert.pem", "#{cert_dir}/key.pem"])
+    end
+
+    def wait_for_httpbin(name, timeout: 30)
+      deadline = Time.now + timeout
+      loop do
+        logs = IO.popen(['docker', 'logs', name], err: [:child, :out], &:read)
+        return if logs.include?('go-httpbin listening on')
+        raise "#{name} did not start listening in #{timeout}s:\n#{logs}" if Time.now > deadline
+
+        sleep 0.2
+      end
+    end
+
+    # systemd wipes /tmp while booting, so commands that write there (`update-ca-certificates`)
+    # fail unless we let it settle first.
+    def wait_for_systemd(timeout: 30)
+      deadline = Time.now + timeout
+      loop do
+        state = IO.popen(
+          ['docker', 'exec', container, 'systemctl', 'is-system-running', '--wait'],
+          err: [:child, :out], &:read
+        ).strip
+        return if %w[running degraded].include?(state)
+        raise "systemd in #{container} did not finish booting in #{timeout}s: #{state}" if Time.now > deadline
+
+        sleep 0.2
+      end
+    end
   end
 
   def apply_recipe(*recipes, cwd: '/', options: [], redirect: {})
@@ -34,17 +96,50 @@ RSpec.configure do |config|
       system('rake', 'compile', "BUILD_TARGET=#{MItamaeSpec::TARGET}", exception: true)
     end
 
+    system('docker', 'rm', '-f', MItamaeSpec.container, MItamaeSpec.httpbin, MItamaeSpec.httpbin_tls)
+    system('docker', 'network', 'rm', MItamaeSpec.network, out: File::NULL, err: File::NULL)
+    system('docker', 'network', 'create', MItamaeSpec.network, out: File::NULL, exception: true)
+
+    MItamaeSpec.generate_certificate
+
+    system(
+      'docker', 'run', '-d', '--rm', '--name', MItamaeSpec.httpbin,
+      '--network', MItamaeSpec.network, '--network-alias', 'httpbin',
+      MItamaeSpec::HTTPBIN_IMAGE, '-port', '8080',
+      out: File::NULL,
+    ) || raise
+    # go-httpbin serves either HTTP or HTTPS per process, so HTTPS needs a second instance.
+    system(
+      'docker', 'run', '-d', '--rm', '--name', MItamaeSpec.httpbin_tls,
+      '--network', MItamaeSpec.network, '--network-alias', 'httpbin-tls',
+      '-v', "#{MItamaeSpec.cert_dir}:/certs:ro",
+      MItamaeSpec::HTTPBIN_IMAGE, '-port', '8443',
+      '-https-cert-file', '/certs/cert.pem', '-https-key-file', '/certs/key.pem',
+      out: File::NULL,
+    ) || raise
+    MItamaeSpec.wait_for_httpbin(MItamaeSpec.httpbin)
+    MItamaeSpec.wait_for_httpbin(MItamaeSpec.httpbin_tls)
+
     # k0kubun/mitamae-spec is automatically built from `spec/Dockerfile`:
     # https://hub.docker.com/r/k0kubun/mitamae-spec/builds/
-    system('docker', 'rm', '-f', MItamaeSpec.container)
     system(
       'docker', 'run', '-d', '--privileged', '--rm', '--name', MItamaeSpec.container,
+      '--network', MItamaeSpec.network,
       '-v', "#{File.expand_path("mruby/build/#{MItamaeSpec::TARGET}")}:/mitamae",
       '-v', "#{File.expand_path('spec/recipes')}:/recipes",
       '-v', "#{File.expand_path('spec/plugins')}:/plugins",
+      '-v', "#{MItamaeSpec.cert_dir}:/certs:ro",
       'k0kubun/mitamae-spec', 'systemd',
     ) || raise
+    MItamaeSpec.wait_for_systemd
+    # Let `curl` in the container trust the self-signed certificate of httpbin-tls
+    system('docker', 'exec', MItamaeSpec.container, 'cp', '/certs/cert.pem', '/usr/local/share/ca-certificates/httpbin-tls.crt', exception: true)
+    system('docker', 'exec', MItamaeSpec.container, 'update-ca-certificates', out: File::NULL, exception: true)
     # Workaround to avoid letting systemd clean up /tmp after `mitamae local`
     system('docker', 'exec', MItamaeSpec.container, 'systemctl', 'start', 'systemd-tmpfiles-clean', out: File::NULL)
+  end
+
+  config.after(:suite) do
+    FileUtils.rm_rf(MItamaeSpec.cert_dir)
   end
 end


### PR DESCRIPTION
The `http_request` specs used to hit httpbin.org and httpbingo.org, so a green
build depended on third-party services being up and reachable.

This runs [go-httpbin](https://github.com/mccutchen/go-httpbin) in a dedicated
Docker network instead, and points every recipe at it. Two instances are needed
because go-httpbin serves either HTTP or HTTPS per process; the HTTPS one gets a
self-signed certificate for the `httpbin-tls` network alias, which the spec
container trusts via `update-ca-certificates`.

Two behavioural differences with go-httpbin had to be accommodated:

- It echoes query parameters and headers as JSON arrays rather than bare
  strings, so the integration expectations now match arrays.
- It rejects `/status/999` with 400, which is indistinguishable from an ordinary
  client error. The unknown-error recipe now connects to a port nobody listens
  on, making curl fail with 7 instead, which is neither 4xx nor 5xx and
  therefore keeps exercising the "unknown error" branch.

Verified locally with `bundle exec rake test:integration` (193 examples, 0 failures).
