### PR TITLE
Fix HTTP status classification in http_request

### DIFF
--- a/mrblib/mitamae/resource_executor/http_request.rb
+++ b/mrblib/mitamae/resource_executor/http_request.rb
@@ -46,7 +46,7 @@ module MItamae
           MItamae.logger.error("#{result.stderr}")
           case result.exit_status
           when 22
-            case result.stderr.gsub(/\Acurl:.*:\s(\d{3}.*)\z/, '\1')
+            case result.stderr.chomp.gsub(/\Acurl:.*:\s(\d{3}.*)\z/, '\1')
             when /\A4\d{2}/
               raise HTTPClientError
             when /\A5\d{2}/

--- a/spec/integration/http_request_spec.rb
+++ b/spec/integration/http_request_spec.rb
@@ -1,23 +1,46 @@
 require 'spec_helper'
+require 'tempfile'
 
 describe 'http_request resource' do
+  # `apply_recipe` passes `redirect:` straight to `system`, where a String value for `err:`
+  # is a filename, so mitamae's stderr can be captured without touching the spec helper.
+  def stderr_of_failed_recipe(recipe)
+    Tempfile.create('mitamae-stderr') do |f|
+      expect {
+        apply_recipe(recipe, redirect: { out: File::NULL, err: f.path })
+      }.to raise_error(RuntimeError)
+      File.read(f.path)
+    end
+  end
+
   before(:all) do
+    # This has to run before any other recipe installs curl.
     expect {
       apply_recipe('http_request_without_curl', redirect: { out: File::NULL })
     }.to raise_error(RuntimeError)
-    expect {
-      apply_recipe('http_request_client_error', redirect: { out: File::NULL })
-    }.to raise_error(RuntimeError)
-    expect {
-      apply_recipe('http_request_server_error', redirect: { out: File::NULL })
-    }.to raise_error(RuntimeError)
-    expect {
-      apply_recipe('http_request_unknown_error', redirect: { out: File::NULL })
-    }.to raise_error(RuntimeError)
-    expect {
-      apply_recipe('http_request_redirect_limit', redirect: { out: File::NULL })
-    }.to raise_error(RuntimeError)
+
+    @stderr = {}
+    %w[client_error server_error unknown_error redirect_limit].each do |name|
+      @stderr[name] = stderr_of_failed_recipe("http_request_#{name}")
+    end
+
     apply_recipe('http_request')
+  end
+
+  it 'raises HTTPClientError for a 4xx response' do
+    expect(@stderr['client_error']).to include('HTTPClientError')
+  end
+
+  it 'raises HTTPServerError for a 5xx response' do
+    expect(@stderr['server_error']).to include('HTTPServerError')
+  end
+
+  it 'raises HTTPUnknownError for a failure that is neither 4xx nor 5xx' do
+    expect(@stderr['unknown_error']).to include('HTTPUnknownError')
+  end
+
+  it 'raises RedirectLimitExceeded when the redirect limit is exceeded' do
+    expect(@stderr['redirect_limit']).to include('RedirectLimitExceeded')
   end
 
   describe file('/tmp/http_request.html') do


### PR DESCRIPTION
`http_request` is meant to raise `HTTPClientError` for 4xx and `HTTPServerError`
for 5xx, but it always raises `HTTPUnknownError` instead.

curl writes its error message with a trailing newline:

    curl: (22) The requested URL returned error: 400 Bad Request\n

`.` does not match a newline and `\z` anchors to the very end of the string, so
`/\Acurl:.*:\s(\d{3}.*)\z/` never matches. `gsub` returns the subject unchanged
when nothing matches, so the `case` compares the full `curl: (22) ...` message
against `/\A4\d{2}/` and `/\A5\d{2}/`, matches neither, and falls through to
`raise HTTPUnknownError`. The status-based branching has been dead since it was
introduced in c5b2e90.

Chomping the trailing newline restores the intended behaviour.

The specs did not catch this because they only assert `raise_error(RuntimeError)`,
which the spec helper raises whenever `docker exec` fails — regardless of which
exception mitamae raised. They now capture mitamae's stderr and assert on the
exception class in a dedicated example per branch, so each one is pinned down.

Verified locally: with only the spec change applied, the 4xx and 5xx examples
fail with `HTTPUnknownError`; with the `chomp` in place all four branches pass.
