### PR TITLE
Fix Node accessor methods broken by mruby's method_missing visibility check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Fix `node.VAR_NAME`, `node.fetch`, `node.to_h` and `node.respond_to?` raising
+  `NoMethodError: private method ... called`, broken since v2.0.0
+
 ## v2.0.1
 
 - Fix HTTP status classification in `http_request`

--- a/mrblib/mitamae/node.rb
+++ b/mrblib/mitamae/node.rb
@@ -48,7 +48,9 @@ module MItamae
     # `method_missing` therefore turns every `node.VAR_NAME`, `node.fetch(...)`
     # and `node.to_h` into `NoMethodError: private method '<name>' called`.
     # This differs from CRuby, which delegates to a private `method_missing`
-    # as usual, and still applies as of mruby 4.0.0.
+    # as usual. It has been fixed upstream in mruby/mruby@9aaa7ce, but the fix
+    # is not in any released version yet, so it still affects every release up
+    # to and including mruby 4.0.0.
     def method_missing(method, *args)
       if @mash.respond_to?(method)
         return @mash.send(method, *args)

--- a/mrblib/mitamae/node.rb
+++ b/mrblib/mitamae/node.rb
@@ -40,12 +40,15 @@ module MItamae
       end
     end
 
-    private
-
-    def _reverse_merge(other_hash)
-      Hashie::Mash.new(other_hash).merge(@mash)
-    end
-
+    # NOTE: Do not move `method_missing` and `respond_to?` below `private`.
+    #
+    # Since mruby 3.4.0, when a method is not found, the VM falls back to
+    # `method_missing` but then checks the visibility of `method_missing`
+    # itself, reporting the *originally called* name. A private
+    # `method_missing` therefore turns every `node.VAR_NAME`, `node.fetch(...)`
+    # and `node.to_h` into `NoMethodError: private method '<name>' called`.
+    # This differs from CRuby, which delegates to a private `method_missing`
+    # as usual, and still applies as of mruby 4.0.0.
     def method_missing(method, *args)
       if @mash.respond_to?(method)
         return @mash.send(method, *args)
@@ -58,6 +61,12 @@ module MItamae
 
     def respond_to?(method, priv = false)
       @mash.respond_to?(method, priv) || super
+    end
+
+    private
+
+    def _reverse_merge(other_hash)
+      Hashie::Mash.new(other_hash).merge(@mash)
     end
 
     def fetch_inventory_value(key)

--- a/spec/integration/node_spec.rb
+++ b/spec/integration/node_spec.rb
@@ -28,6 +28,31 @@ describe 'node object' do
     its(:content) { should eq('node2') }
   end
 
+  describe file('/tmp/node_method') do
+    it { should be_file }
+    its(:content) { should eq('node.json') }
+  end
+
+  describe file('/tmp/node_fetch') do
+    it { should be_file }
+    its(:content) { should eq('node.yml') }
+  end
+
+  describe file('/tmp/node_fetch_missing') do
+    it { should be_file }
+    its(:content) { should eq('KeyError') }
+  end
+
+  describe file('/tmp/node_to_h') do
+    it { should be_file }
+    its(:content) { should eq('deep,greeting,node_json,node_yml') }
+  end
+
+  describe file('/tmp/node_respond_to') do
+    it { should be_file }
+    its(:content) { should eq('true,false') }
+  end
+
   describe file('/tmp/node_assign') do
     it { should be_file }
     its(:content) { should eq("hello: hello\nworld: world\n") }

--- a/spec/recipes/node.rb
+++ b/spec/recipes/node.rb
@@ -14,6 +14,33 @@ file '/tmp/node2' do
   content node[:deep][:node2]
 end
 
+file '/tmp/node_method' do
+  content node.node_json
+end
+
+file '/tmp/node_fetch' do
+  content node.fetch('node_yml')
+end
+
+file '/tmp/node_fetch_missing' do
+  content(
+    begin
+      node.fetch('missing_key')
+      'no error'
+    rescue KeyError
+      'KeyError'
+    end
+  )
+end
+
+file '/tmp/node_to_h' do
+  content node.to_h.keys.sort.join(',')
+end
+
+file '/tmp/node_respond_to' do
+  content [node.respond_to?(:node_json), node.respond_to?(:missing_key)].join(',')
+end
+
 template '/tmp/node_assign'
 
 template '/tmp/node_merge'


### PR DESCRIPTION
Fixes the regression reported in #151.

## Problem

Since v2.0.0, every `node` accessor that goes through `method_missing` fails:

```
node.foo               #=> NoMethodError: private method 'foo' called for MItamae::Node
node.fetch('foo')      #=> NoMethodError: private method 'fetch' called for MItamae::Node
node.to_h              #=> NoMethodError: private method 'to_h' called for MItamae::Node
node.respond_to?(:foo) #=> NoMethodError: private method 'respond_to?' called for MItamae::Node
```

Only `node[:key]` still works, which is the least safe option: it silently returns
`nil` on a typo, whereas `fetch` raises `KeyError`.

## Cause

mruby 3.4.0 started enforcing method visibility. When a method is not found, the VM
falls back to `method_missing` — but then checks the visibility flag of the
**`method_missing` method itself**, while still naming the *originally called* method
in the error
([`src/vm.c#L1904-L1915`](https://github.com/mruby/mruby/blob/3.4.0/src/vm.c#L1904-L1915)):

```c
m = mrb_vm_find_method(mrb, ci->u.target_class, &ci->u.target_class, mid);
if (MRB_METHOD_UNDEF_P(m)) {
  m = prepare_missing(mrb, ci, recv, mid, blk, (insn == OP_SUPER));  /* m = method_missing */
}
else {
  ci->mid = mid;
}
if (insn == OP_SEND || insn == OP_SENDB) {
  if (m.flags & MRB_METHOD_PRIVATE_FL) {
    mrb_value args = (ci->n == 15) ? regs[1] : mrb_ary_new_from_values(mrb, ci->n, regs+1);
    mrb_no_method_error(mrb, mid, args, "private method '%n' called for %T", mid, recv);
  }
```

[`prepare_missing()`](https://github.com/mruby/mruby/blob/3.4.0/src/vm.c#L606-L643)
returns the `method_missing` method, so `m.flags` no longer describes the method the
caller actually named. That is why the failure reads `private method 'to_h' called`
even though `Node` never defines `to_h`.

`MItamae::Node#method_missing` was defined under `private`, following the usual Ruby
convention. That was harmless on mruby 3.0.0, which ignored `private` entirely, but on
3.4.0 it makes every delegated call fail. `Node#respond_to?` sat in the same `private`
section, so it became private outright.

This is not specific to 3.4.0 — mruby 4.0.0 and current master behave identically
([4.0.0 `src/vm.c#L2309-L2327`](https://github.com/mruby/mruby/blob/4.0.0/src/vm.c#L2309-L2327)),
so the fix stays valid across future mruby upgrades. Confirmed on a 4.0.0 build:

```ruby
class WithPrivateMM
  def initialize; @h = { 'foo' => 'bar' }; end
  private
  def method_missing(name, *args)
    return @h[name.to_s] if @h.key?(name.to_s)
    super
  end
end
WithPrivateMM.new.foo
#=> mruby 4.0.0: NoMethodError: private method 'foo' called for WithPrivateMM
#=> CRuby 4.0.6: "bar"
```

It also diverges from CRuby, which delegates to a private `method_missing` as usual, so
it may be worth reporting upstream to mruby separately.

## Fix

Move `method_missing` and `respond_to?` above the `private` keyword, with a comment
explaining why they must stay public. `_reverse_merge` and `fetch_inventory_value`
remain private.

`ResourceContext#method_missing` has the same shape but is not affected: resource
blocks are `instance_exec`'d, so attribute calls compile to `OP_SSEND`, which skips the
visibility check. It is left as is.

## Verification

Behavior after the fix:

```
node.foo               #=> "bar"
node.fetch('foo')      #=> "bar"
node.fetch('nope')     #=> KeyError: Key not found: "nope"
node.to_h              #=> #<Hashie::Mash foo="bar" nested=#<Hashie::Mash a=1>>
node.respond_to?(:foo) #=> true
node.no_such_thing     #=> NoMethodError: undefined method 'no_such_thing' for MItamae::Node
```

Note that the last two lines matter as much as the rest: making `method_missing` public
does not weaken anything. Unknown names still raise `undefined method` through `super`,
and genuinely private methods called with an explicit receiver are still rejected.

Regression coverage for `node.VAR_NAME`, `node.fetch` (both a hit and a `KeyError`
miss), `node.to_h` and `node.respond_to?` is added to `spec/recipes/node.rb` and
`spec/integration/node_spec.rb`. The full integration suite passes: 207 examples,
0 failures.
