### PR TITLE
Fix run_command keyword arguments, which were broken in v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix `run_command` keyword arguments in recipes, broken since v2.0.0
+
 ## v2.0.2
 
 - Fix `node.VAR_NAME`, `node.fetch`, `node.to_h` and `node.respond_to?` raising

--- a/mrblib/mitamae/recipe_loader.rb
+++ b/mrblib/mitamae/recipe_loader.rb
@@ -10,7 +10,7 @@ module MItamae
       backend = @backend
       variables = {
         node: @node,
-        run_command: -> (*args) { backend.run_command(*args) },
+        run_command: -> (*args, **opts) { backend.run_command(*args, **opts) },
       }
 
       root = RecipeRoot.new

--- a/spec/recipes/run_command.rb
+++ b/spec/recipes/run_command.rb
@@ -2,6 +2,10 @@ unless run_command("echo -n Hello").stdout == "Hello"
   raise "run_command in a recipe failed"
 end
 
+unless run_command("false", error: false).exit_status == 1
+  raise "run_command with keyword argument (error: false) failed"
+end
+
 define :run_command_in_definition do
   unless run_command("echo -n Hello").stdout == "Hello"
     raise "run_command in a definition failed"


### PR DESCRIPTION
## Behavior change from v1.14.4

`run_command` exposed to recipes is defined in `mrblib/mitamae/recipe_loader.rb` as a lambda, and its definition is unchanged since v1.14.4:

```ruby
run_command: -> (*args) { backend.run_command(*args) },
```

What changed is the mruby underneath it. v1.14.4 was built on mruby 3.0.0, which still folds keyword arguments into a trailing Hash of `*args`, so `run_command("...", error: false)` reached `MItamae::Backend#run_command(command, error: true, ...)` and was re-expanded into the `error:` keyword. `error: false` was honored.

The current master builds on mruby 3.4.0, which implements Ruby 3 style keyword argument separation. The lambda declares no keyword parameter, so the Hash is no longer re-expanded on the way out — it is passed to the backend as a *second positional argument*:

| | v1.14.4 (mruby 3.0.0) | master (mruby 3.4.0) |
| --- | --- | --- |
| `run_command("cmd")` | works | works |
| `run_command("cmd", error: false)` | works, `error: false` honored | `ArgumentError: wrong number of arguments (given 2, expected 1)` |

So any recipe that passes `error:`, `user:`, `cwd:`, or `log_output:` to the top-level `run_command` — which worked in v1.14.4 — aborts on v2.x. This PR adds `**kwargs` to the lambda and forwards it explicitly, restoring the v1.14.4 behavior.

Note that this only affects the top-level `run_command` in recipes. `MItamae::Runner.run_command` and `ResourceExecutor::Base#run_command` already declare `**opts`, so resources were never broken.

## Test plan
- [x] Added a regression case in `spec/recipes/run_command.rb`
