### PR TITLE
Fix run_command options passed as a positional Hash, broken since v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix `run_command` options passed as a positional Hash, broken since v2.0.0
+
 ## v2.0.3
 
 - Fix `run_command` keyword arguments in recipes, broken since v2.0.0

--- a/mrblib/mitamae/compat.rb
+++ b/mrblib/mitamae/compat.rb
@@ -130,3 +130,22 @@ module Open3
     [stdout_and_stderr_str, status]
   end
 end
+
+module MItamae
+  # mruby 3.4.0 implements Ruby 3 style keyword argument separation, so a
+  # trailing Hash is no longer folded into keyword arguments. Recipes and
+  # plugins written against v1.x pass options as a positional Hash, e.g.
+  # `run_command(cmd, opts)` or `run_command(cmd, { error: false })`, which
+  # reaches `Backend#run_command` as a second positional argument and raises
+  # `ArgumentError`. Fold it back into the keywords ourselves.
+  #
+  # Explicit keywords win over the Hash, so that a caller which builds options
+  # from both sources (`run_command(cmd, opts, cwd: dir)`) behaves as written.
+  def self.merge_trailing_options(args, opts)
+    if args.size > 1 && args.last.is_a?(Hash)
+      args = args.dup
+      opts = args.pop.merge(opts)
+    end
+    [args, opts]
+  end
+end

--- a/mrblib/mitamae/recipe_loader.rb
+++ b/mrblib/mitamae/recipe_loader.rb
@@ -10,7 +10,10 @@ module MItamae
       backend = @backend
       variables = {
         node: @node,
-        run_command: -> (*args, **opts) { backend.run_command(*args, **opts) },
+        run_command: -> (*args, **opts) {
+          args, opts = MItamae.merge_trailing_options(args, opts)
+          backend.run_command(*args, **opts)
+        },
       }
 
       root = RecipeRoot.new

--- a/mrblib/mitamae/resource_executor/base.rb
+++ b/mrblib/mitamae/resource_executor/base.rb
@@ -155,6 +155,9 @@ module MItamae
       end
 
       def run_command(*args, **opts)
+        # Fold a positional Hash in before the defaults below, so that a `user`
+        # or `cwd` passed that way still takes precedence over the attributes.
+        args, opts = MItamae.merge_trailing_options(args, opts)
         opts[:user] ||= attributes.user
         opts[:cwd]  ||= attributes.cwd
         @runner.run_command(*args, **opts)

--- a/mrblib/mitamae/runner.rb
+++ b/mrblib/mitamae/runner.rb
@@ -12,6 +12,7 @@ module MItamae
     end
 
     def run_command(*args, **opts)
+      args, opts = MItamae.merge_trailing_options(args, opts)
       @backend.run_command(*args, **opts)
     end
 

--- a/spec/plugins/mitamae-plugin-resource-test/mrblib/resource_executor/test.rb
+++ b/spec/plugins/mitamae-plugin-resource-test/mrblib/resource_executor/test.rb
@@ -5,6 +5,10 @@ module ::MItamae
         def apply
           if desired.created
             run_command("echo #{desired.message}")
+            options = { error: false }
+            unless run_command('false', options).exit_status == 1
+              raise 'run_command with a positional Hash option failed'
+            end
             File.open('/tmp/mitamae-plugin-resource-test-file', 'w') do |io|
               io.write(__FILE__)
             end

--- a/spec/recipes/run_command.rb
+++ b/spec/recipes/run_command.rb
@@ -6,6 +6,11 @@ unless run_command("false", error: false).exit_status == 1
   raise "run_command with keyword argument (error: false) failed"
 end
 
+options = { error: false }
+unless run_command("false", options).exit_status == 1
+  raise "run_command with a positional Hash option failed"
+end
+
 define :run_command_in_definition do
   unless run_command("echo -n Hello").stdout == "Hello"
     raise "run_command in a definition failed"


### PR DESCRIPTION
v2.0.3 (#158) restored `run_command("cmd", error: false)` by declaring `**kwargs`
on the recipe-level lambda, but the other half of the v1.x calling convention is
still broken. Recipes and plugins also pass options as a positional Hash:

```ruby
options = { error: false }
run_command("cmd", options)
run_command("cmd", { error: false })
```

mruby 3.0.0 folded a trailing Hash into keyword arguments on the way out, so both
forms reached `Backend#run_command(command, error: true, ...)` and the options
were honored, as they were in v1.14.4. mruby 3.4.0 implements Ruby 3 style
keyword argument separation, so the Hash stays positional and the backend
rejects it:

```
backend.rb:12:in run_command: wrong number of arguments (given 2, expected 1) (ArgumentError)
```

## Fix

Add `MItamae.merge_trailing_options` to fold such a Hash back into the keywords,
and call it where the options are consumed:

- `RecipeLoader`'s `run_command` lambda and `Runner#run_command`, which forward
  straight to the backend.
- `ResourceExecutor::Base#run_command`, which must normalize *before* applying
  `attributes.user` / `attributes.cwd`, otherwise a `user` or `cwd` given in the
  Hash would lose to the resource attributes.

`check_command` and `Git#run_command_in_repo` need no change: they only force an
option and delegate to `run_command`, which normalizes for them, and the forced
option keeps winning over the Hash as it did before.

Explicit keywords take precedence over the Hash, so a caller mixing both
(`run_command(cmd, options, cwd: dir)`) behaves as written. That form raised
`ArgumentError` on v1.14.4, so nothing regresses.

## Verification

Built binaries from v1.14.4 and from this branch and compared every calling form:

| | v1.14.4 | v2.0.3 | this branch |
|---|---|---|---|
| `run_command("false", error: false)` | 1 | 1 | 1 |
| `run_command("false", options)` | 1 | `ArgumentError` | 1 |
| `run_command("false", { error: false })` | 1 | `ArgumentError` | 1 |
| `run_command("pwd", { cwd: "/etc" })` | `/etc` | `ArgumentError` | `/etc` |
| `run_command("pwd", options, cwd: "/etc")` | `ArgumentError` | `ArgumentError` | `/etc` |

The recipes under `spec/recipes` that run without root also produce
byte-identical output between v1.14.4 and this branch.

## Tests

Regression cases cover both code paths that recipes and plugins actually reach:

- `spec/recipes/run_command.rb` for the recipe-level lambda.
- the test plugin's resource executor for `ResourceExecutor::Base#run_command`,
  which runs through `spec/recipes/plugins.rb`.

Confirmed both fail when `merge_trailing_options` is stubbed out to a no-op.
