### PR TITLE
Fix resource attributes broken when set through an explicit receiver

### DIFF
--- a/mrblib/mitamae/resource_context.rb
+++ b/mrblib/mitamae/resource_context.rb
@@ -43,12 +43,17 @@ module MItamae
       @resource.verify_commands << command
     end
 
-    private
-
-    def respond_to_missing?(method, include_private = false)
-      @resource.class.defined_attributes.has_key?(method) || super
-    end
-
+    # NOTE: Do not move `method_missing` below `private`. See the same note in
+    # node.rb.
+    #
+    # Since mruby 3.4.0, when a method is not found, the VM falls back to
+    # `method_missing` but then checks the visibility of `method_missing`
+    # itself, reporting the *originally called* name. A private
+    # `method_missing` therefore turns `ctx.owner 'root'` into
+    # `NoMethodError: private method 'owner' called` whenever the resource
+    # context is reached through an explicit receiver. Attribute calls with an
+    # implicit self, which is how recipes are usually written, keep working
+    # because calling a private method that way is legitimate.
     def method_missing(method, *args, &block)
       if @resource.class.defined_attributes[method]
         smethod = method.to_s
@@ -64,6 +69,12 @@ module MItamae
       # TODO: build mruby with MRB_DEFAULT_METHOD_MISSING
       # super
       raise NoMethodError, "undefined method `#{method}' for #{self.class}"
+    end
+
+    private
+
+    def respond_to_missing?(method, include_private = false)
+      @resource.class.defined_attributes.has_key?(method) || super
     end
   end
 end

--- a/spec/integration/file_spec.rb
+++ b/spec/integration/file_spec.rb
@@ -99,4 +99,20 @@ describe 'file resource' do
   describe file('/tmp/file_changed_notifies') do
     its(:content) { should eq('1') }
   end
+
+  describe file('/tmp/file_attributes_by_helper') do
+    it { should be_file }
+    its(:content) { should eq('Hello World') }
+    it { should be_mode 600 }
+  end
+
+  describe file('/tmp/file_attributes_read_by_helper') do
+    it { should be_file }
+    its(:content) { should eq('Hello WorldHello World') }
+  end
+
+  describe file('/tmp/file_undefined_attribute') do
+    it { should be_file }
+    its(:content) { should eq("undefined method `no_such_attribute' for MItamae::ResourceContext") }
+  end
 end

--- a/spec/recipes/file.rb
+++ b/spec/recipes/file.rb
@@ -189,3 +189,38 @@ file '/tmp/file_changed_sample' do
   content 'Changed'
   notifies :run, 'execute[echo -n 1 > /tmp/file_changed_notifies]'
 end
+
+### Test attributes set through an explicit receiver, as a helper taking the resource does
+
+apply_defaults = lambda do |resource|
+  resource.content 'Hello World'
+  resource.mode '600'
+end
+
+repeat_content = lambda do |resource|
+  resource.content resource.content * 2
+end
+
+undefined_attribute = lambda do |resource|
+  resource.no_such_attribute
+end
+
+file '/tmp/file_attributes_by_helper' do
+  apply_defaults.call(self)
+end
+
+file '/tmp/file_attributes_read_by_helper' do
+  content 'Hello World'
+  repeat_content.call(self)
+end
+
+file '/tmp/file_undefined_attribute' do
+  content(
+    begin
+      undefined_attribute.call(self)
+      'no error'
+    rescue NoMethodError => e
+      e.message
+    end
+  )
+end


### PR DESCRIPTION
## Problem

Setting a resource attribute through an explicit receiver has been broken since v2.0.0:

```ruby
apply_common = lambda do |resource|
  resource.owner 'root'
  resource.mode  '0600'
end

file '/tmp/x' do
  content 'hello'
  apply_common.call(self)
end
```

```
v1.14.4: INFO : file[/tmp/x] mode will be '0600'
         INFO : file[/tmp/x] owner will be 'root'
v2.0.3 : private method 'owner' called for MItamae::ResourceContext (NoMethodError)
```

Reading an attribute back (`resource.content`) fails the same way, and asking a resource context for an attribute that does not exist now reports `private method 'no_such_attribute' called` instead of `undefined method`.

| Call | v1.14.4 | v2.0.3 |
|---|---|---|
| `content 'x'` (implicit self) | OK | OK |
| `self.content 'x'` | OK | OK |
| `send(:content, 'x')` | OK | OK |
| `resource.content 'x'` (explicit receiver) | OK | `private method 'content' called` |
| `resource.content` (reading) | OK | `private method 'content' called` |
| `resource.no_such_attribute` | `undefined method` | `private method ... called` |

## Cause

`MItamae::ResourceContext#method_missing` is defined under `private`. Since mruby 3.4.0, when a method is not found the VM falls back to `method_missing` but then checks the visibility of `method_missing` itself, reporting the *originally called* name. CRuby delegates to a private `method_missing` as usual, so this only shows up on mruby. It is fixed upstream in mruby/mruby@9aaa7ce, but the fix is not in any released version yet.

This is the same problem #157 fixed for `MItamae::Node`; `ResourceContext` was left untouched at the time.

`self.content 'x'` still works because mruby 3.4.0 compiles `self.method` calls into OP_SSEND, which is treated as a self call and therefore permits private methods. A call through a variable is a plain OP_SEND and is rejected.

## Why the specs stayed green

The standard way of writing a recipe (`file '/tmp/x' do content 'y' end`) calls attributes with an implicit self, which is a legitimate way of calling a private method. No spec reached a resource context through an explicit receiver. `Node` was noticed immediately because `node.foo` is its intended usage.

## Fix

Move `method_missing` above `private`, leaving `respond_to_missing?` private where it belongs, and add a note so it is not moved back. `respond_to?` keeps working through the private `respond_to_missing?`.

## Test

`spec/recipes/file.rb` now sets attributes through a helper that takes the resource, reads an attribute back through it, and records the error raised for an attribute that does not exist. All three fail without this change.
